### PR TITLE
Add options for generated enum format.

### DIFF
--- a/pbtools/c_source/__init__.py
+++ b/pbtools/c_source/__init__.py
@@ -693,22 +693,31 @@ OPTIONAL_STRUCT_MEMBER_FMT = '''\
 
 class GeneratorOptions:
 
-    def __init__(self):
-        self.enum_prefix = 2
-        self.enum_upper = False
+    _enum_formatters = {
+        'namespace-and-type': ENUM_MEMBER_FMT.format,
+        'namespace': ENUM_MEMBER_PREFIX_NS_FMT.format,
+        'none': ENUM_MEMBER_PREFIX_NONE_FMT.format
+    }
+
+    def enum_prefixes():
+        return list(GeneratorOptions._enum_formatters.keys())
+
+    def __init__(self, enum_prefix, enum_upper):
+        self.enum_prefix = enum_prefix
+        self.enum_upper = enum_upper
 
 
 class Generator:
 
-    def __init__(self, namespace, parsed, header_name, gen_opts):
+    def __init__(self, namespace, parsed, header_name, options):
         if parsed.package is not None:
             namespace = camel_to_snake_case(parsed.package)
 
         self.namespace = namespace
         self.parsed = parsed
         self.header_name = header_name
-        self.enum_prefix = gen_opts.enum_prefix
-        self.enum_upper = gen_opts.enum_upper
+        self.enum_prefix = options.enum_prefix
+        self.enum_upper = options.enum_upper
 
     @property
     def messages(self):
@@ -830,12 +839,7 @@ class Generator:
         return REPEATED_MESSAGE_STRUCT_FMT.format(message=message)
 
     def generate_enum_members(self, enum):
-        if self.enum_prefix == 0:
-            format_func = ENUM_MEMBER_PREFIX_NONE_FMT.format
-        elif self.enum_prefix == 1:
-            format_func = ENUM_MEMBER_PREFIX_NS_FMT.format
-        else:
-            format_func = ENUM_MEMBER_FMT.format
+        format_func = GeneratorOptions._enum_formatters[self.enum_prefix]
         lines = []
         for field in enum.fields:
             line = format_func(enum=enum, field=field)

--- a/pbtools/parser.py
+++ b/pbtools/parser.py
@@ -335,6 +335,10 @@ class Enum:
             self.fields.append(EnumField(item))
 
     @property
+    def namespace_snake_case(self):
+        return camel_to_snake_case('.'.join(self.namespace))
+
+    @property
     def full_name(self):
         return '.'.join(self.namespace + [self.name])
 

--- a/pbtools/subparsers/generate_c_source.py
+++ b/pbtools/subparsers/generate_c_source.py
@@ -2,12 +2,17 @@ import os
 
 from ..parser import camel_to_snake_case
 from ..c_source import generate_files
+from ..c_source import GeneratorOptions
 
 
 def _do_generate_c_source(args):
+    gen_opts = GeneratorOptions()
+    gen_opts.enum_prefix = args.enum_prefix
+    gen_opts.enum_upper = args.enum_upper
     generate_files(args.infiles,
                    args.import_path,
-                   args.output_directory)
+                   args.output_directory,
+                   gen_opts)
 
 
 def add_subparser(subparsers):
@@ -27,4 +32,13 @@ def add_subparser(subparsers):
         'infiles',
         nargs='+',
         help='Input protobuf file(s).')
+    subparser.add_argument(
+        '--enum-prefix',
+        default=2,
+        type=int,
+        help='set generated enum prefix, 0: none, 1: namespace, else: namespace and type')
+    subparser.add_argument(
+        '--enum-upper',
+        action='store_true',
+        help='use upper case for generated enum')
     subparser.set_defaults(func=_do_generate_c_source)

--- a/pbtools/subparsers/generate_c_source.py
+++ b/pbtools/subparsers/generate_c_source.py
@@ -7,7 +7,6 @@ from ..c_source import GeneratorOptions
 
 def _do_generate_c_source(args):
     options = GeneratorOptions(
-        enum_prefix=args.enum_prefix,
         enum_upper=args.enum_upper
     )
     generate_files(args.infiles,
@@ -33,11 +32,6 @@ def add_subparser(subparsers):
         'infiles',
         nargs='+',
         help='Input protobuf file(s).')
-    subparser.add_argument(
-        '--enum-prefix',
-        choices=GeneratorOptions.enum_prefixes(),
-        default=GeneratorOptions.enum_prefixes()[0],
-        help='set generated enum prefix')
     subparser.add_argument(
         '--enum-upper',
         action='store_true',

--- a/pbtools/subparsers/generate_c_source.py
+++ b/pbtools/subparsers/generate_c_source.py
@@ -6,13 +6,14 @@ from ..c_source import GeneratorOptions
 
 
 def _do_generate_c_source(args):
-    gen_opts = GeneratorOptions()
-    gen_opts.enum_prefix = args.enum_prefix
-    gen_opts.enum_upper = args.enum_upper
+    options = GeneratorOptions(
+        enum_prefix=args.enum_prefix,
+        enum_upper=args.enum_upper
+    )
     generate_files(args.infiles,
                    args.import_path,
                    args.output_directory,
-                   gen_opts)
+                   options)
 
 
 def add_subparser(subparsers):
@@ -34,9 +35,9 @@ def add_subparser(subparsers):
         help='Input protobuf file(s).')
     subparser.add_argument(
         '--enum-prefix',
-        default=2,
-        type=int,
-        help='set generated enum prefix, 0: none, 1: namespace, else: namespace and type')
+        choices=GeneratorOptions.enum_prefixes(),
+        default=GeneratorOptions.enum_prefixes()[0],
+        help='set generated enum prefix')
     subparser.add_argument(
         '--enum-upper',
         action='store_true',


### PR DESCRIPTION
I too ran into this issue https://github.com/eerimoq/pbtools/issues/9.  Here is one way to handle that.
I addition, I usually use all upper case for enum constants, so I added an option for that as well.